### PR TITLE
Update imports to match rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Operator Boilerplate
+# Operator Boilerplate (Legacy)
 
 Operator Boilerplate is a tiny library containing a few helpers to make writing an operator or custom controller easier by abstracting some of the repetitive mechanisms common to most controllers. 
 

--- a/doc.go
+++ b/doc.go
@@ -1,1 +1,1 @@
-package _go // import "monis.app/go"
+package _go // import "github.com/openshift/operator-boilerplate"

--- a/go.mod
+++ b/go.mod
@@ -1,27 +1,8 @@
-module github.com/openshift/operator-boilerplate
+module github.com/openshift/operator-boilerplate-legacy
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 // indirect
-	github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 // indirect
-	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
-	github.com/hashicorp/golang-lru v0.5.0 // indirect
-	github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be // indirect
-	github.com/kr/pretty v0.1.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/spf13/pflag v1.0.1 // indirect
-	github.com/stretchr/testify v1.3.0 // indirect
-	golang.org/x/crypto v0.0.0-20190506204251-e1dfcc566284 // indirect
-	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
-	golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db // indirect
-	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/inf.v0 v0.9.0 // indirect
-	gopkg.in/yaml.v2 v2.2.1 // indirect
-	k8s.io/api v0.0.0-20190222213804-5cb15d344471 // indirect
+	github.com/openshift/operator-boilerplate v0.0.0-20191011182912-6c1da56b7d1a
 	k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
 	k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4
 	k8s.io/klog v0.3.0
-	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/openshift/operator-boilerplate v0.0.0-20191011182912-6c1da56b7d1a h1:Os/3zC5Nsa/GS09ul53NAc9AYuk48A3WHwj2YvWwo70=
+github.com/openshift/operator-boilerplate v0.0.0-20191011182912-6c1da56b7d1a/go.mod h1:gm2x4aRLemAAselw4tZ6NcFuzqkZX1j/LfRD5qPWhcc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/pflag v1.0.1 h1:aCvUg6QPl3ibpQUxyLkrEkCHtPqYJL4x9AuhqVqFis4=

--- a/openshift/operator/filter.go
+++ b/openshift/operator/filter.go
@@ -1,6 +1,6 @@
 package operator
 
-import "monis.app/go/openshift/controller"
+import "github.com/openshift/operator-boilerplate-legacy/openshift/controller"
 
 func FilterByNames(names ...string) controller.Filter {
 	return controller.FilterByNames(nil, names...)

--- a/openshift/operator/operator.go
+++ b/openshift/operator/operator.go
@@ -1,6 +1,6 @@
 package operator
 
-import "monis.app/go/openshift/controller"
+import "github.com/openshift/operator-boilerplate-legacy/openshift/controller"
 
 type Runner interface {
 	Run(stopCh <-chan struct{})

--- a/openshift/operator/option.go
+++ b/openshift/operator/option.go
@@ -1,9 +1,9 @@
 package operator
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"monis.app/go/openshift/controller"
+	"github.com/openshift/operator-boilerplate-legacy/openshift/controller"
 )
 
 type Option func(*operator)

--- a/openshift/operator/sync.go
+++ b/openshift/operator/sync.go
@@ -1,9 +1,8 @@
 package operator
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"monis.app/go/openshift/controller"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/openshift/operator-boilerplate-legacy/openshift/controller"
 )
 
 type KeySyncer interface {


### PR DESCRIPTION
Imports within this repo still reference the original name prior to moving it under the OpenShift org.  